### PR TITLE
Bugfix: Stop throwing a missing-class-property-error when only @dataMember is specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "santee-dcts",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "DataContractSerializer for TypeScript. (any -> Class)",
   "main": "index.js",
   "scripts": {

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -103,7 +103,7 @@ function deepCopyAssignment(target: Object, targetPropertyName: (string | symbol
 
 function deserializeAssignment(constructorFunction: new () => any): assignmentFunction {
     return function (target: Object, targetPropertyName: (string | symbol), sourceValue: any) {
-        var deserializedValue: any = sourceValue === null ? null : deserialize(sourceValue, constructorFunction);
+        var deserializedValue: any = sourceValue == null ? sourceValue : deserialize(sourceValue, constructorFunction);
         (<any>target)[targetPropertyName] = deserializedValue;
     };
 }

--- a/tests/deserializerTests.ts
+++ b/tests/deserializerTests.ts
@@ -74,14 +74,24 @@ describe("deserialize(obj, constructorFunction)", () => {
     });
 
     it("assigns undefined if property does not exist and no @required decorator specified", () => {
+        class B {
+            @dataMember()
+            public baz: string;
+        };
+
         class A {
             @dataMember()
             public foo: string;
+
+            @dataMember()
+            public b: B;
         };
 
         var source = { bar: 5 };
 
-        expect(deserialize(source, A).foo).to.be.undefined;
+        var result = deserialize(source, A);
+        expect(result.foo).to.be.undefined;
+        expect(result.b).to.be.undefined;
     });
 
     it("allows nulls to be assigned to primitive types", () => {

--- a/tests/requiredDecoratorTest.ts
+++ b/tests/requiredDecoratorTest.ts
@@ -43,7 +43,7 @@ describe("@required()", () => {
     }
     );
 
-    it(`makes deserialize() function to fail if source value is undefined`, () => {
+    it(`makes deserialize() function to fail if source value (primitive) is undefined`, () => {
         class A {
             @dataMember()
             @required()
@@ -55,6 +55,22 @@ describe("@required()", () => {
         expect(() => deserialize(source, A)).to.throw(Error);
     });
 
+    it(`makes deserialize() function to fail if source value (object) is undefined`, () => {
+        class B {
+            @dataMember()
+            public foo: string;
+        }
+
+        class A {
+            @dataMember()
+            @required()
+            public b: B;
+        }
+        
+        var source = { bar: "test" };
+        
+        expect(() => deserialize(source, A)).to.throw(Error);
+    });
 
     it(`makes deserialize() function to fail if source value is null`, () => {
         class A {


### PR DESCRIPTION
This should prevent throwing `'source object must be an object'` error for cases
when an optional property that links to another class has `undefined` value.
The property has `@dataMember()` specified but does **NOT** have `@required()` specified.

![image](https://user-images.githubusercontent.com/45663769/63347739-67f69200-c360-11e9-90ed-6eff93690fc9.png)
